### PR TITLE
Fix Cloudflare SFU API documentation - Add missing sessionDescription and bidirectionalMediaStream examples

### DIFF
--- a/public/realtime/static/calls-api-2024-05-21.yaml
+++ b/public/realtime/static/calls-api-2024-05-21.yaml
@@ -32,6 +32,26 @@ paths:
           schema:
             type: string
           description: Associate session to an user-provided correlation id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewSessionRequest"
+            examples:
+              with_session_description:
+                description: Create a new session with an initial sessionDescription
+                value:
+                  sessionDescription:
+                    sdp: |
+                      v=0
+                      o=- 0 0 IN IP4 127.0.0.1
+                      s=-
+                      c=IN IP4 127.0.0.1
+                      t=0 0
+                      m=audio 4000 RTP/AVP 111
+                      a=rtpmap:111 OPUS/48000/2
+                      ...
+                    type: offer
       responses:
         "201":
           description: Created
@@ -108,12 +128,13 @@ paths:
                       bidirectionalMediaStream: true
                       kind: "audio"
               push_track_without_an_offer:
-                description: SFU can generate an offer to push a local track
+                description: SFU can generate an offer to push a local track. Note that bidirectionalMediaStream is required when the SFU generates the offer for pushing a local track.
                 value:
                   tracks:
                     - location: local
                       trackName: mic-1
                       kind: "audio"
+                      bidirectionalMediaStream: true
               push_tracks_with_autodiscover:
                 description: SFU detects any new track in the offered SDP
                 value:


### PR DESCRIPTION
## Description

This PR addresses the documentation gaps reported in issue #18.

## Changes Made

### 1. Added requestBody documentation to `/apps/{appId}/sessions/new`
- Added a `requestBody` section with an example showing how to create a new session with a `sessionDescription` parameter
- Previously, this parameter existed in the schema but was not documented with examples

### 2. Fixed `push_track_without_an_offer` example
- Added `bidirectionalMediaStream: true` to the example in `/apps/{appId}/sessions/{sessionId}/tracks/new`
- Updated the description to clarify that `bidirectionalMediaStream` is required when the SFU generates the offer for pushing a local track
- This fixes the issue where the original example didn't work without this parameter

## Validation

✅ Issue #1: `sessionDescription` parameter is now documented for `/apps/{appId}/sessions/new`
✅ Issue #2: `push_track_without_an_offer` example now includes the required `bidirectionalMediaStream: true` parameter

Fixes #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI/spec changes with no runtime behavior impact; risk is limited to potential client confusion if the examples/schema are still inaccurate.
> 
> **Overview**
> Updates the `calls-api-2024-05-21.yaml` OpenAPI spec to document a JSON `requestBody` for `POST /apps/{appId}/sessions/new`, including an example that supplies an initial `sessionDescription` SDP offer.
> 
> Fixes the `push_track_without_an_offer` example for `POST /apps/{appId}/sessions/{sessionId}/tracks/new` by adding `bidirectionalMediaStream: true` and clarifying in the description that it’s required when the SFU generates the offer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a60b0d3125617d551f0317d4789a7a6560bb6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->