### PR TITLE
Fix: Clarify Build command is required in Pages UI

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-anything.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-anything.mdx
@@ -17,15 +17,21 @@ Cloudflare supports deploying any static HTML website to Cloudflare Pages. If yo
 
 <div>
 
-| Configuration option     | Value              |
-| ------------------------ | ------------------ |
-| Production branch        | `main`             |
-| Build command (optional) | `exit 0`           |
-| Build output directory   | `<YOUR_BUILD_DIR>` |
+| Configuration option   | Value              |
+| ---------------------- | ------------------ |
+| Production branch      | `main`             |
+| Build command          | `exit 0`           |
+| Build output directory | `<YOUR_BUILD_DIR>` |
 
 </div>
 
-Unlike many of the framework guides, the build command and build output directory for your site are going to be completely custom. If you are not using a preset and do not need to build your site, use `exit 0` as your **Build command**. Cloudflare recommends using `exit 0` as your **Build command** to access features such as Pages Functions. The **Build output directory** is where your application's content lives.
+:::note
+
+The **Build command** field is required in the Cloudflare Pages dashboard. Even if you do not need to build your site, you must provide a command.
+
+:::
+
+Unlike many of the framework guides, the build command and build output directory for your site are going to be completely custom. If you are not using a preset and do not need to build your site, use `exit 0` as your **Build command**. Using `exit 0` allows your deployment to succeed immediately while still giving you access to features such as Pages Functions. The **Build output directory** is where your application's content lives.
 
 After configuring your site, you can begin your first deploy. Your custom build command (if provided) will run, and Pages will deploy your static site.
 


### PR DESCRIPTION
## Summary

Fixes #21

This PR clarifies that the Build command field is **required** in the Cloudflare Pages dashboard, even when deploying static HTML sites that don't need a build step.

## Changes Made

1. **Updated table**: Removed "(optional)" label from "Build command" row to avoid confusion
2. **Added note callout**: Explicitly states that the Build command field is required in the UI
3. **Enhanced explanation**: Clarified that `exit 0` allows deployment to succeed immediately while maintaining access to Pages Functions

## Why These Changes?

The previous documentation labeled the Build command as "(optional)" in the table, which was misleading because:
- The field is actually **required** in the Cloudflare Pages UI
- Users must provide a value, even if it's just `exit 0`
- This was causing confusion for users trying to deploy static sites

## Result

The documentation now clearly indicates that while you don't need to *build* anything, you must provide a Build command value (`exit 0` is recommended for static sites).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes clarifying configuration fields; no code or runtime behavior is affected.
> 
> **Overview**
> Updates the Static HTML Pages deployment guide to remove the “(optional)” implication for **Build command**, explicitly stating it’s required in the Pages dashboard.
> 
> Adds a `:::note` callout and tweaks the explanation to recommend `exit 0` as a no-op command that still enables successful deploys and access to Pages Functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e3194b8282d1a13b2400c20721a8afeef0a13ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->